### PR TITLE
add vnet warning logics when provide managed environment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3489,30 +3489,33 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
     client = web_client_factory(cmd.cli_ctx)
 
     if vnet or subnet:
-        if plan:
-            if is_valid_resource_id(plan):
-                parse_result = parse_resource_id(plan)
-                plan_info = client.app_service_plans.get(parse_result['resource_group'], parse_result['name'])
-            else:
-                plan_info = client.app_service_plans.get(resource_group_name, plan)
-            webapp_location = plan_info.location
+        if environment is not None:
+            logger.warning("Placeholder warning message")
         else:
-            webapp_location = consumption_plan_location
+            if plan:
+                if is_valid_resource_id(plan):
+                    parse_result = parse_resource_id(plan)
+                    plan_info = client.app_service_plans.get(parse_result['resource_group'], parse_result['name'])
+                else:
+                    plan_info = client.app_service_plans.get(resource_group_name, plan)
+                webapp_location = plan_info.location
+            else:
+                webapp_location = consumption_plan_location
 
-        subnet_info = _get_subnet_info(cmd=cmd,
-                                       resource_group_name=resource_group_name,
-                                       subnet=subnet,
-                                       vnet=vnet)
-        _validate_vnet_integration_location(cmd=cmd, webapp_location=webapp_location,
-                                            subnet_resource_group=subnet_info["resource_group_name"],
-                                            vnet_name=subnet_info["vnet_name"],
-                                            vnet_sub_id=subnet_info["subnet_subscription_id"])
-        _vnet_delegation_check(cmd, subnet_subscription_id=subnet_info["subnet_subscription_id"],
-                               vnet_resource_group=subnet_info["resource_group_name"],
-                               vnet_name=subnet_info["vnet_name"],
-                               subnet_name=subnet_info["subnet_name"])
-        site_config.vnet_route_all_enabled = True
-        subnet_resource_id = subnet_info["subnet_resource_id"]
+            subnet_info = _get_subnet_info(cmd=cmd,
+                                        resource_group_name=resource_group_name,
+                                        subnet=subnet,
+                                        vnet=vnet)
+            _validate_vnet_integration_location(cmd=cmd, webapp_location=webapp_location,
+                                                subnet_resource_group=subnet_info["resource_group_name"],
+                                                vnet_name=subnet_info["vnet_name"],
+                                                vnet_sub_id=subnet_info["subnet_subscription_id"])
+            _vnet_delegation_check(cmd, subnet_subscription_id=subnet_info["subnet_subscription_id"],
+                                vnet_resource_group=subnet_info["resource_group_name"],
+                                vnet_name=subnet_info["vnet_name"],
+                                subnet_name=subnet_info["subnet_name"])
+            site_config.vnet_route_all_enabled = True
+            subnet_resource_id = subnet_info["subnet_resource_id"]
     else:
         subnet_resource_id = None
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3491,6 +3491,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
     if vnet or subnet:
         if environment is not None:
             logger.warning("Placeholder warning message")
+            subnet_resource_id = None
         else:
             if plan:
                 if is_valid_resource_id(plan):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3490,7 +3490,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
 
     if vnet or subnet:
         if environment is not None:
-            logger.warning("Placeholder warning message")
+            logger.warning("This function app is created in an App Environment. Go to App environment to configure Networking")
             subnet_resource_id = None
         else:
             if plan:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_functionapp_create_with_appcontainer_managed_environment.yaml
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/recordings/test_functionapp_create_with_appcontainer_managed_environment.yaml
@@ -1,0 +1,4695 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","East US 2","West Europe","Central US","East
+        US","North Europe","South Central US","UK South","West US 3","Central US EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","East US 2","West Europe","Central US","East
+        US","North Europe","South Central US","UK South","West US 3","Central US EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8082'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:46:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","East US 2","West Europe","Central US","East
+        US","North Europe","South Central US","UK South","West US 3","Central US EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","East US 2","West Europe","Central US","East
+        US","North Europe","South Central US","UK South","West US 3","Central US EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8082'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:46:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","East US 2","West Europe","Central US","East
+        US","North Europe","South Central US","UK South","West US 3","Central US EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","East US 2","West Europe","Central US","East
+        US","North Europe","South Central US","UK South","West US 3","Central US EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8082'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:46:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App","namespace":"Microsoft.App","authorizations":[{"applicationId":"7e3bc4fd-85a3-4192-b177-5b8bfc87f42c","roleDefinitionId":"39a74f72-b40f-4bdc-b639-562fe2260bf0"},{"applicationId":"3734c1a4-2bed-4998-a37a-ff1a9e7bf019","roleDefinitionId":"5c779a4f-5cb2-4547-8c41-478d9be8ba90"},{"applicationId":"55ebbb62-3b9c-49fd-9b87-9595226dd4ac","roleDefinitionId":"e49ca620-7992-4561-a7df-4ed67dad77b5","managedByRoleDefinitionId":"9e3af657-a8ff-583c-a75c-2fe7c4bcb635"}],"resourceTypes":[{"resourceType":"managedEnvironments","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/certificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"managedEnvironments/managedCertificates","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-11-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"containerApps","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/managedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationResults","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"locations/containerappOperationStatuses","locations":["North
+        Central US (Stage)","Canada Central","West Europe","North Europe","East US","East
+        US 2","East Asia","Australia East","Germany West Central","Japan East","UK
+        South","West US","Central US","North Central US","South Central US","Korea
+        Central","Brazil South","West US 3","France Central","South Africa North","Norway
+        East","Switzerland North","UAE North","Central US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"operations","locations":["North
+        Central US (Stage)","Central US EUAP","East US 2 EUAP","Canada Central","West
+        Europe","North Europe","East US","East US 2","East Asia","Australia East","Germany
+        West Central","Japan East","UK South","West US","Central US","North Central
+        US","South Central US","Korea Central","Brazil South","West US 3","France
+        Central","South Africa North","Norway East","Switzerland North","UAE North"],"apiVersions":["2022-11-01-preview","2022-10-01","2022-06-01-preview","2022-03-01","2022-01-01-preview"],"capabilities":"None"},{"resourceType":"connectedEnvironments","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"connectedEnvironments/certificates","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/connectedEnvironmentOperationResults","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/connectedEnvironmentOperationStatuses","locations":["North
+        Central US (Stage)","North Central US","East US","East Asia","West Europe","Central
+        US EUAP","East US 2 EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/billingMeters","locations":["North
+        Central US (Stage)","Australia East","East US 2","West Europe","Central US","East
+        US","North Europe","South Central US","UK South","West US 3","Central US EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"},{"resourceType":"locations/availableManagedEnvironmentsWorkloadProfileTypes","locations":["North
+        Central US (Stage)","Australia East","East US 2","West Europe","Central US","East
+        US","North Europe","South Central US","UK South","West US 3","Central US EUAP"],"apiVersions":["2022-10-01","2022-06-01-preview"],"capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '8082'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:46:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.OperationalInsights?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorizations":[{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},{"applicationId":"ca7f3f0b-7d91-482c-8e09-c5d840d0eac5","roleDefinitionId":"5d5a2e56-9835-44aa-93db-d2f19e155438"}],"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2021-06-01","2021-03-01-privatepreview","2020-10-01","2020-08-01","2020-03-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"querypacks","locations":["West Central
+        US","East US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2","UK South","Canada Central","Central India","Japan East","Australia
+        East","Korea Central","France Central","Central US","East US 2","East Asia","West
+        US","South Africa North","North Central US","Brazil South","Switzerland North","Norway
+        East","Australia Southeast","Australia Central 2","Germany West Central","Switzerland
+        West","UAE Central","UK West","Brazil Southeast","Japan West","UAE North","Australia
+        Central","France South","South India","Korea South","Jio India Central","Jio
+        India West","Qatar Central","Canada East","West US 3","Sweden Central"],"apiVersions":["2019-09-01-preview","2019-09-01"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"locations/operationStatuses","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/scopedPrivateLinkProxies","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-03-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/metadata","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/linkedStorageAccounts","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/tables","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia East","Australia
+        Central","France Central","Korea Central","North Europe","Central US","East
+        Asia","East US 2","South Central US","North Central US","West US","UK West","South
+        Africa North","Brazil South","Switzerland North","Switzerland West","Germany
+        West Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2020-08-01","2020-03-01-preview","2017-04-26-preview"],"capabilities":"None"},{"resourceType":"workspaces/storageInsightConfigs","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia East","Australia
+        Central","France Central","Korea Central","North Europe","Central US","East
+        Asia","East US 2","South Central US","North Central US","West US","UK West","South
+        Africa North","Brazil South","Switzerland North","Switzerland West","Germany
+        West Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"capabilities":"None"},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2020-08-01","2020-03-01-preview","2014-10-10"],"capabilities":"SupportsExtension"},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2020-03-01-preview","2015-03-20"],"capabilities":"None"},{"resourceType":"deletedWorkspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"operations","locations":[],"apiVersions":["2022-10-01","2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview","2015-11-01-preview","2014-11-10"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"clusters","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Switzerland North","Switzerland West","Germany West Central","Australia
+        Central 2","UAE Central","Brazil South","UAE North","Japan West","Brazil Southeast","Norway
+        East","Norway West","France South","South India","Korea South","Jio India
+        Central","Jio India West","Qatar Central","Canada East","West US 3","Sweden
+        Central"],"apiVersions":["2021-06-01","2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2021-06-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"workspaces/dataExports","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12443'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:46:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.OperationalInsights?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorizations":[{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},{"applicationId":"ca7f3f0b-7d91-482c-8e09-c5d840d0eac5","roleDefinitionId":"5d5a2e56-9835-44aa-93db-d2f19e155438"}],"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2021-06-01","2021-03-01-privatepreview","2020-10-01","2020-08-01","2020-03-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"querypacks","locations":["West Central
+        US","East US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2","UK South","Canada Central","Central India","Japan East","Australia
+        East","Korea Central","France Central","Central US","East US 2","East Asia","West
+        US","South Africa North","North Central US","Brazil South","Switzerland North","Norway
+        East","Australia Southeast","Australia Central 2","Germany West Central","Switzerland
+        West","UAE Central","UK West","Brazil Southeast","Japan West","UAE North","Australia
+        Central","France South","South India","Korea South","Jio India Central","Jio
+        India West","Qatar Central","Canada East","West US 3","Sweden Central"],"apiVersions":["2019-09-01-preview","2019-09-01"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"locations/operationStatuses","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/scopedPrivateLinkProxies","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-03-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/metadata","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/linkedStorageAccounts","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/tables","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia East","Australia
+        Central","France Central","Korea Central","North Europe","Central US","East
+        Asia","East US 2","South Central US","North Central US","West US","UK West","South
+        Africa North","Brazil South","Switzerland North","Switzerland West","Germany
+        West Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2020-08-01","2020-03-01-preview","2017-04-26-preview"],"capabilities":"None"},{"resourceType":"workspaces/storageInsightConfigs","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia East","Australia
+        Central","France Central","Korea Central","North Europe","Central US","East
+        Asia","East US 2","South Central US","North Central US","West US","UK West","South
+        Africa North","Brazil South","Switzerland North","Switzerland West","Germany
+        West Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"capabilities":"None"},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2020-08-01","2020-03-01-preview","2014-10-10"],"capabilities":"SupportsExtension"},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2020-03-01-preview","2015-03-20"],"capabilities":"None"},{"resourceType":"deletedWorkspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"operations","locations":[],"apiVersions":["2022-10-01","2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview","2015-11-01-preview","2014-11-10"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"clusters","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Switzerland North","Switzerland West","Germany West Central","Australia
+        Central 2","UAE Central","Brazil South","UAE North","Japan West","Brazil Southeast","Norway
+        East","Norway West","France South","South India","Korea South","Jio India
+        Central","Jio India West","Qatar Central","Canada East","West US 3","Sweden
+        Central"],"apiVersions":["2021-06-01","2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2021-06-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"workspaces/dataExports","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12443'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:46:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.OperationalInsights?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorizations":[{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},{"applicationId":"ca7f3f0b-7d91-482c-8e09-c5d840d0eac5","roleDefinitionId":"5d5a2e56-9835-44aa-93db-d2f19e155438"}],"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2021-06-01","2021-03-01-privatepreview","2020-10-01","2020-08-01","2020-03-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"querypacks","locations":["West Central
+        US","East US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2","UK South","Canada Central","Central India","Japan East","Australia
+        East","Korea Central","France Central","Central US","East US 2","East Asia","West
+        US","South Africa North","North Central US","Brazil South","Switzerland North","Norway
+        East","Australia Southeast","Australia Central 2","Germany West Central","Switzerland
+        West","UAE Central","UK West","Brazil Southeast","Japan West","UAE North","Australia
+        Central","France South","South India","Korea South","Jio India Central","Jio
+        India West","Qatar Central","Canada East","West US 3","Sweden Central"],"apiVersions":["2019-09-01-preview","2019-09-01"],"capabilities":"SupportsTags,
+        SupportsLocation"},{"resourceType":"locations","locations":[],"apiVersions":["2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"locations/operationStatuses","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/scopedPrivateLinkProxies","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-03-01-preview","capabilities":"None"},{"resourceType":"workspaces/query","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/metadata","locations":[],"apiVersions":["2017-10-01"],"capabilities":"None"},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/linkedStorageAccounts","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"workspaces/tables","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia East","Australia
+        Central","France Central","Korea Central","North Europe","Central US","East
+        Asia","East US 2","South Central US","North Central US","West US","UK West","South
+        Africa North","Brazil South","Switzerland North","Switzerland West","Germany
+        West Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2022-10-01","2021-12-01-preview","2020-08-01","2020-03-01-preview","2017-04-26-preview"],"capabilities":"None"},{"resourceType":"workspaces/storageInsightConfigs","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia East","Australia
+        Central","France Central","Korea Central","North Europe","Central US","East
+        Asia","East US 2","South Central US","North Central US","West US","UK West","South
+        Africa North","Brazil South","Switzerland North","Switzerland West","Germany
+        West Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"],"capabilities":"None"},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2020-08-01","2020-03-01-preview","2014-10-10"],"capabilities":"SupportsExtension"},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview","2015-11-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2020-03-01-preview","2015-03-20"],"capabilities":"None"},{"resourceType":"deletedWorkspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"operations","locations":[],"apiVersions":["2022-10-01","2021-12-01-preview","2020-10-01","2020-08-01","2020-03-01-preview","2015-11-01-preview","2014-11-10"],"defaultApiVersion":"2020-08-01","capabilities":"None"},{"resourceType":"clusters","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Switzerland North","Switzerland West","Germany West Central","Australia
+        Central 2","UAE Central","Brazil South","UAE North","Japan West","Brazil Southeast","Norway
+        East","Norway West","France South","South India","Korea South","Jio India
+        Central","Jio India West","Qatar Central","Canada East","West US 3","Sweden
+        Central"],"apiVersions":["2021-06-01","2020-10-01","2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2021-06-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SystemAssignedResourceIdentity, SupportsTags,
+        SupportsLocation"},{"resourceType":"workspaces/dataExports","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central","West US 2","Australia Central","Australia
+        East","France Central","Korea Central","North Europe","Central US","East Asia","East
+        US 2","South Central US","North Central US","West US","UK West","South Africa
+        North","Brazil South","Switzerland North","Switzerland West","Germany West
+        Central","Australia Central 2","UAE Central","UAE North","Japan West","Brazil
+        Southeast","Norway East","Norway West","France South","South India","Korea
+        South","Jio India Central","Jio India West","Qatar Central","Canada East","West
+        US 3","Sweden Central"],"apiVersions":["2020-08-01","2020-03-01-preview","2019-08-01-preview"],"defaultApiVersion":"2020-08-01","capabilities":"None"}],"registrationState":"Registered","registrationPolicy":"RegistrationRequired"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12443'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:46:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus", "properties": {"publicNetworkAccessForIngestion":
+      "Enabled", "publicNetworkAccessForQuery": "Enabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-mgmt-loganalytics/13.0.0b4 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace-clitestrgw3rgdpxkr634ai76bm3xn?api-version=2021-12-01-preview
+  response:
+    body:
+      string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
+        \"6b942a94-14c9-413d-ad0f-6fc9a402ce9e\",\r\n    \"provisioningState\": \"Creating\",\r\n
+        \   \"sku\": {\r\n      \"name\": \"pergb2018\",\r\n      \"lastSkuUpdate\":
+        \"Tue, 31 Jan 2023 18:46:41 GMT\"\r\n    },\r\n    \"retentionInDays\": 30,\r\n
+        \   \"features\": {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n
+        \     \"enableLogAccessUsingOnlyResourcePermissions\": true\r\n    },\r\n
+        \   \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": -1.0,\r\n      \"quotaNextResetTime\":
+        \"Wed, 01 Feb 2023 12:00:00 GMT\",\r\n      \"dataIngestionStatus\": \"RespectQuota\"\r\n
+        \   },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n    \"publicNetworkAccessForQuery\":
+        \"Enabled\",\r\n    \"createdDate\": \"Tue, 31 Jan 2023 18:46:41 GMT\",\r\n
+        \   \"modifiedDate\": \"Tue, 31 Jan 2023 18:46:41 GMT\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace-clitestrgw3rgdpxkr634ai76bm3xn\",\r\n
+        \ \"name\": \"workspace-clitestrgw3rgdpxkr634ai76bm3xn\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
+        \ \"location\": \"eastus\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1114'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:46:41 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-mgmt-loganalytics/13.0.0b4 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace-clitestrgw3rgdpxkr634ai76bm3xn?api-version=2021-12-01-preview
+  response:
+    body:
+      string: "{\r\n  \"properties\": {\r\n    \"source\": \"Azure\",\r\n    \"customerId\":
+        \"6b942a94-14c9-413d-ad0f-6fc9a402ce9e\",\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"sku\": {\r\n      \"name\": \"pergb2018\",\r\n      \"lastSkuUpdate\":
+        \"Tue, 31 Jan 2023 18:46:41 GMT\"\r\n    },\r\n    \"retentionInDays\": 30,\r\n
+        \   \"features\": {\r\n      \"legacy\": 0,\r\n      \"searchVersion\": 1,\r\n
+        \     \"enableLogAccessUsingOnlyResourcePermissions\": true\r\n    },\r\n
+        \   \"workspaceCapping\": {\r\n      \"dailyQuotaGb\": -1.0,\r\n      \"quotaNextResetTime\":
+        \"Wed, 01 Feb 2023 12:00:00 GMT\",\r\n      \"dataIngestionStatus\": \"RespectQuota\"\r\n
+        \   },\r\n    \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n    \"publicNetworkAccessForQuery\":
+        \"Enabled\",\r\n    \"createdDate\": \"Tue, 31 Jan 2023 18:46:41 GMT\",\r\n
+        \   \"modifiedDate\": \"Tue, 31 Jan 2023 18:46:43 GMT\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/microsoft.operationalinsights/workspaces/workspace-clitestrgw3rgdpxkr634ai76bm3xn\",\r\n
+        \ \"name\": \"workspace-clitestrgw3rgdpxkr634ai76bm3xn\",\r\n  \"type\": \"Microsoft.OperationalInsights/workspaces\",\r\n
+        \ \"location\": \"eastus\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1115'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:47:11 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-mgmt-loganalytics/13.0.0b4 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.OperationalInsights/workspaces/workspace-clitestrgw3rgdpxkr634ai76bm3xn/sharedKeys?api-version=2020-08-01
+  response:
+    body:
+      string: "{\r\n  \"primarySharedKey\": \"oUB7pxQ25NHsBEcyYBDa1xJFS2asgysx1Z4prkjgfPbwgIGBxLk6IfO12zOEwtb7lD+DwWLcY3MUgaUU34rBeA==\",\r\n
+        \ \"secondarySharedKey\": \"jHTP21rzeZttNPQmx8VEF6faHXw5RArJ8cw4uhF+y8W51nF/crp6rFdB/glYcGs6GTE/Vao/IE9aJxs46o3kBA==\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      cachecontrol:
+      - no-cache
+      content-length:
+      - '235'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-ams-apiversion:
+      - WebAPI1.0
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "centraluseuap", "tags": null, "sku": {"name": "Consumption"},
+      "properties": {"daprAIInstrumentationKey": null, "vnetConfiguration": null,
+      "internalLoadBalancerEnabled": null, "appLogsConfiguration": {"destination":
+      "log-analytics", "logAnalyticsConfiguration": {"customerId": "6b942a94-14c9-413d-ad0f-6fc9a402ce9e",
+      "sharedKey": "oUB7pxQ25NHsBEcyYBDa1xJFS2asgysx1Z4prkjgfPbwgIGBxLk6IfO12zOEwtb7lD+DwWLcY3MUgaUU34rBeA=="}},
+      "customDomainConfiguration": null, "zoneRedundant": false}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '496'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307Z","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307Z"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/centraluseuap/managedEnvironmentOperationStatuses/6353d4c5-8682-4709-9494-06dc3bab7e37?api-version=2022-06-01-preview&azureAsyncOperation=true
+      cache-control:
+      - no-cache
+      content-length:
+      - '1207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-async-operation-timeout:
+      - PT15M
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:47:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:48:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:49:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:50:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:50:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Waiting","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1205'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:50:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - containerapp env create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --name --resource-group --location
+      User-Agent:
+      - python/3.8.10 (Windows-10-10.0.22621-SP0) AZURECLI/2.44.1
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Succeeded","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false,"eventStreamEndpoint":"https://centraluseuap.azurecontainerapps.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/managedEnvironments/containerappmanagedenvironment000004/eventstream","customDomainConfiguration":{"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7"}},"sku":{"name":"Consumption"}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '1207'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:50:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-web/7.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions?sku=Dynamic&api-version=2022-03-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US","name":"East US","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US","description":null,"sortOrder":0,"displayName":"East US","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;FAKEORG;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/North
+        Europe","name":"North Europe","type":"Microsoft.Web/geoRegions","properties":{"name":"North
+        Europe","description":null,"sortOrder":1,"displayName":"North Europe","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;LINUXDYNAMIC;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        Europe","name":"West Europe","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        Europe","description":null,"sortOrder":2,"displayName":"West Europe","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;LINUXFREE;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Southeast
+        Asia","name":"Southeast Asia","type":"Microsoft.Web/geoRegions","properties":{"name":"Southeast
+        Asia","description":null,"sortOrder":3,"displayName":"Southeast Asia","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;LINUXDYNAMIC;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Asia","name":"East Asia","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        Asia","description":null,"sortOrder":4,"displayName":"East Asia","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;SFCONTAINERS;LINUXDYNAMIC;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        US","name":"West US","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        US","description":null,"sortOrder":5,"displayName":"West US","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;LINUXDYNAMIC;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Japan
+        West","name":"Japan West","type":"Microsoft.Web/geoRegions","properties":{"name":"Japan
+        West","description":null,"sortOrder":7,"displayName":"Japan West","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;LINUXDYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Japan
+        East","name":"Japan East","type":"Microsoft.Web/geoRegions","properties":{"name":"Japan
+        East","description":null,"sortOrder":8,"displayName":"Japan East","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXFREE;ELASTICLINUX;ELASTICPREMIUM;LINUXDYNAMIC;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US 2","name":"East US 2","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US 2","description":null,"sortOrder":9,"displayName":"East US 2","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/North
+        Central US","name":"North Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"North
+        Central US","description":null,"sortOrder":10,"displayName":"North Central
+        US","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM;ELASTICLINUX;LINUXDYNAMIC;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        Central US","name":"South Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"South
+        Central US","description":null,"sortOrder":11,"displayName":"South Central
+        US","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Brazil
+        South","name":"Brazil South","type":"Microsoft.Web/geoRegions","properties":{"name":"Brazil
+        South","description":null,"sortOrder":12,"displayName":"Brazil South","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        East","name":"Australia East","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
+        East","description":null,"sortOrder":13,"displayName":"Australia East","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;XENON;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        Southeast","name":"Australia Southeast","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
+        Southeast","description":null,"sortOrder":14,"displayName":"Australia Southeast","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Central
+        US","name":"Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"Central
+        US","description":null,"sortOrder":15,"displayName":"Central US","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        Asia (Stage)","name":"East Asia (Stage)","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        Asia (Stage)","description":null,"sortOrder":2147483647,"displayName":"East
+        Asia (Stage)","orgDomain":"MSFTINT;DSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;XENON;LINUX;LINUXFREE;LINUXDYNAMIC;XENONV3;WINDOWSV3;LINUXV3;WINDOWSMV3;LINUXMV3;WINDOWSP0V3;LINUXP0V3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Central
+        India","name":"Central India","type":"Microsoft.Web/geoRegions","properties":{"name":"Central
+        India","description":null,"sortOrder":2147483647,"displayName":"Central India","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        India","name":"West India","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        India","description":null,"sortOrder":2147483647,"displayName":"West India","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICPREMIUM;LINUXDYNAMIC;ELASTICLINUX"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        India","name":"South India","type":"Microsoft.Web/geoRegions","properties":{"name":"South
+        India","description":null,"sortOrder":2147483647,"displayName":"South India","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Canada
+        Central","name":"Canada Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Canada
+        Central","description":null,"sortOrder":2147483647,"displayName":"Canada Central","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Canada
+        East","name":"Canada East","type":"Microsoft.Web/geoRegions","properties":{"name":"Canada
+        East","description":null,"sortOrder":2147483647,"displayName":"Canada East","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        Central US","name":"West Central US","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        Central US","description":null,"sortOrder":2147483647,"displayName":"West
+        Central US","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;ELASTICLINUX;ELASTICPREMIUM;MSFTPUBLIC;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        US 2","name":"West US 2","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        US 2","description":null,"sortOrder":2147483647,"displayName":"West US 2","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;DSERIES;LINUXDSERIES;LINUXFREE;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/UK
+        West","name":"UK West","type":"Microsoft.Web/geoRegions","properties":{"name":"UK
+        West","description":null,"sortOrder":2147483647,"displayName":"UK West","orgDomain":"PUBLIC;MSFTPUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/UK
+        South","name":"UK South","type":"Microsoft.Web/geoRegions","properties":{"name":"UK
+        South","description":null,"sortOrder":2147483647,"displayName":"UK South","orgDomain":"PUBLIC;MSFTPUBLIC;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/East
+        US 2 EUAP","name":"East US 2 EUAP","type":"Microsoft.Web/geoRegions","properties":{"name":"East
+        US 2 EUAP","description":null,"sortOrder":2147483647,"displayName":"East US
+        2 EUAP","orgDomain":"EUAP;XENON;DSERIES;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;LINUX;LINUXFREE;ELASTICLINUX;WINDOWSV3;XENONV3;LINUXV3;LINUXDYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Central
+        US EUAP","name":"Central US EUAP","type":"Microsoft.Web/geoRegions","properties":{"name":"Central
+        US EUAP","description":null,"sortOrder":2147483647,"displayName":"Central
+        US EUAP","orgDomain":"EUAP;LINUX;DSERIES;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;ELASTICLINUX;LINUXDYNAMIC;DYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Korea
+        South","name":"Korea South","type":"Microsoft.Web/geoRegions","properties":{"name":"Korea
+        South","description":null,"sortOrder":2147483647,"displayName":"Korea South","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;ELASTICLINUX;FUNCTIONS;DYNAMIC;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Korea
+        Central","name":"Korea Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Korea
+        Central","description":null,"sortOrder":2147483647,"displayName":"Korea Central","orgDomain":"PUBLIC;DREAMSPARK;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;DSERIES;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/France
+        South","name":"France South","type":"Microsoft.Web/geoRegions","properties":{"name":"France
+        South","description":null,"sortOrder":2147483647,"displayName":"France South","orgDomain":"PUBLIC;LINUX;LINUXDSERIES;DSERIES;MSFTPUBLIC;FUNCTIONS;DYNAMIC;ELASTICPREMIUM;ELASTICLINUX"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/France
+        Central","name":"France Central","type":"Microsoft.Web/geoRegions","properties":{"name":"France
+        Central","description":null,"sortOrder":2147483647,"displayName":"France Central","orgDomain":"PUBLIC;MSFTPUBLIC;DSERIES;DYNAMIC;LINUX;LINUXDSERIES;ELASTICPREMIUM;LINUXFREE;LINUXDYNAMIC;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        Central 2","name":"Australia Central 2","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
+        Central 2","description":null,"sortOrder":2147483647,"displayName":"Australia
+        Central 2","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Australia
+        Central","name":"Australia Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Australia
+        Central","description":null,"sortOrder":2147483647,"displayName":"Australia
+        Central","orgDomain":"PUBLIC;FUNCTIONS;DYNAMIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;ELASTICPREMIUM;ELASTICLINUX;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/South
+        Africa North","name":"South Africa North","type":"Microsoft.Web/geoRegions","properties":{"name":"South
+        Africa North","description":null,"sortOrder":2147483647,"displayName":"South
+        Africa North","orgDomain":"PUBLIC;MSFTPUBLIC;FUNCTIONS;DYNAMIC;LINUX;LINUXDSERIES;DSERIES;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;LINUXDYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Switzerland
+        North","name":"Switzerland North","type":"Microsoft.Web/geoRegions","properties":{"name":"Switzerland
+        North","description":null,"sortOrder":2147483647,"displayName":"Switzerland
+        North","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;FUNCTIONS;DYNAMIC;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Germany
+        West Central","name":"Germany West Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Germany
+        West Central","description":null,"sortOrder":2147483647,"displayName":"Germany
+        West Central","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;ELASTICLINUX;LINUXDYNAMIC;XENON;XENONV3;WINDOWSV3;LINUXV3;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Germany
+        North","name":"Germany North","type":"Microsoft.Web/geoRegions","properties":{"name":"Germany
+        North","description":null,"sortOrder":2147483647,"displayName":"Germany North","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;LINUXV3;ELASTICPREMIUM;ELASTICLINUX;FUNCTIONS;DYNAMIC;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Switzerland
+        West","name":"Switzerland West","type":"Microsoft.Web/geoRegions","properties":{"name":"Switzerland
+        West","description":null,"sortOrder":2147483647,"displayName":"Switzerland
+        West","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;FUNCTIONS;DYNAMIC;ELASTICPREMIUM;ELASTICLINUX;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/UAE
+        North","name":"UAE North","type":"Microsoft.Web/geoRegions","properties":{"name":"UAE
+        North","description":null,"sortOrder":2147483647,"displayName":"UAE North","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;LINUXFREE;FUNCTIONS;DYNAMIC;LINUXDYNAMIC;ELASTICPREMIUM;ELASTICLINUX;XENON;XENONV3;WINDOWSV3;LINUXV3;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Norway
+        West","name":"Norway West","type":"Microsoft.Web/geoRegions","properties":{"name":"Norway
+        West","description":null,"sortOrder":2147483647,"displayName":"Norway West","orgDomain":"PUBLIC;DSERIES;MSFTPUBLIC;LINUX;LINUXDSERIES;FUNCTIONS;DYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Norway
+        East","name":"Norway East","type":"Microsoft.Web/geoRegions","properties":{"name":"Norway
+        East","description":null,"sortOrder":2147483647,"displayName":"Norway East","orgDomain":"PUBLIC;LINUX;LINUXDSERIES;DSERIES;ELASTICLINUX;ELASTICPREMIUM;FUNCTIONS;DYNAMIC;XENON;XENONV3;WINDOWSV3;LINUXV3;MSFTPUBLIC;LINUXDYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Brazil
+        Southeast","name":"Brazil Southeast","type":"Microsoft.Web/geoRegions","properties":{"name":"Brazil
+        Southeast","description":null,"sortOrder":2147483647,"displayName":"Brazil
+        Southeast","orgDomain":"PUBLIC;LINUX;LINUXDSERIES;DSERIES;LINUXFREE;FUNCTIONS;DYNAMIC;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/West
+        US 3","name":"West US 3","type":"Microsoft.Web/geoRegions","properties":{"name":"West
+        US 3","description":null,"sortOrder":2147483647,"displayName":"West US 3","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;XENON;XENONV3;WINDOWSV3;LINUXV3;ELASTICPREMIUM;ELASTICLINUX;FUNCTIONS;DYNAMIC;LINUXDYNAMIC;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Jio
+        India West","name":"Jio India West","type":"Microsoft.Web/geoRegions","properties":{"name":"Jio
+        India West","description":null,"sortOrder":2147483647,"displayName":"Jio India
+        West","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;ELASTICPREMIUM;ELASTICLINUX;FUNCTIONS;DYNAMIC;LINUXDYNAMIC;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Jio
+        India Central","name":"Jio India Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Jio
+        India Central","description":null,"sortOrder":2147483647,"displayName":"Jio
+        India Central","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;MSFTPUBLIC;DYNAMIC;FUNCTIONS"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Sweden
+        Central","name":"Sweden Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Sweden
+        Central","description":null,"sortOrder":2147483647,"displayName":"Sweden Central","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;XENON;XENONV3;WINDOWSV3;LINUXV3;ELASTICPREMIUM;ELASTICLINUX;FUNCTIONS;DYNAMIC;MSFTPUBLIC;LINUXDYNAMIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Qatar
+        Central","name":"Qatar Central","type":"Microsoft.Web/geoRegions","properties":{"name":"Qatar
+        Central","description":null,"sortOrder":2147483647,"displayName":"Qatar Central","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;XENON;XENONV3;WINDOWSV3;LINUXV3;ELASTICPREMIUM;ELASTICLINUX;FUNCTIONS;DYNAMIC;MSFTPUBLIC"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/geoRegions/Sweden
+        South","name":"Sweden South","type":"Microsoft.Web/geoRegions","properties":{"name":"Sweden
+        South","description":null,"sortOrder":2147483647,"displayName":"Sweden South","orgDomain":"PUBLIC;DSERIES;LINUX;LINUXDSERIES;XENON;XENONV3;WINDOWSV3;LINUXV3;ELASTICPREMIUM;ELASTICLINUX;FUNCTIONS;DYNAMIC;MSFTPUBLIC"}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20254'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:50:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-web/7.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Web/functionAppStacks?api-version=2022-03-01
+  response:
+    body:
+      string: '{"value":[{"id":null,"name":"dotnet","type":"Microsoft.Web/functionAppStacks?stackOsType=All","properties":{"displayText":".NET","value":"dotnet","preferredOs":"windows","majorVersions":[{"displayText":".NET
+        Framework 4.8","value":"dotnetframework48","minorVersions":[{"displayText":".NET
+        Framework 4.8","value":"4.8","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"4.8.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet-isolated"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4"]}}}]},{"displayText":".NET
+        7 Isolated","value":"dotnet7isolated","minorVersions":[{"displayText":".NET
+        7 Isolated","value":"7 (STS)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.0.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet-isolated"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"netFrameworkVersion":"v7.0"},"supportedFunctionsExtensionVersions":["~4"]},"linuxRuntimeSettings":{"runtimeVersion":"DOTNET-ISOLATED|7.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"7.0.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet-isolated"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"linuxFxVersion":"DOTNET-ISOLATED|7.0"},"supportedFunctionsExtensionVersions":["~4"]}}}]},{"displayText":".NET
+        6","value":"dotnet6","minorVersions":[{"displayText":".NET 6","value":"6","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","isDefault":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4"]},"linuxRuntimeSettings":{"runtimeVersion":"DOTNET|6.0","isDefault":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"linuxFxVersion":"DOTNET|6.0"},"supportedFunctionsExtensionVersions":["~4"]}}}]},{"displayText":".NET
+        6 Isolated","value":"dotnet6isolated","minorVersions":[{"displayText":".NET
+        6 Isolated","value":"6 Isolated","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet-isolated"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4"]},"linuxRuntimeSettings":{"runtimeVersion":"DOTNET-ISOLATED|6.0","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"6.0.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet-isolated"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"linuxFxVersion":"DOTNET-ISOLATED|6.0"},"supportedFunctionsExtensionVersions":["~4"]}}}]},{"displayText":".NET
+        5 (non-LTS)","value":"dotnet5","minorVersions":[{"displayText":".NET 5 (non-LTS)","value":"5
+        (non-LTS)","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"v5.0","isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet-isolated"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true},"supportedFunctionsExtensionVersions":["~3"],"endOfLifeDate":"2022-05-08T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"DOTNET-ISOLATED|5.0","isHidden":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"5.0.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet-isolated"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"linuxFxVersion":"DOTNET-ISOLATED|5.0"},"supportedFunctionsExtensionVersions":["~3"],"endOfLifeDate":"2022-05-08T00:00:00Z"}}}]},{"displayText":".NET
+        Core 3","value":"dotnetcore3","minorVersions":[{"displayText":".NET Core 3.1","value":"3.1","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"3.1","appInsightsSettings":{"isSupported":true},"remoteDebuggingSupported":false,"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true},"supportedFunctionsExtensionVersions":["~3"],"endOfLifeDate":"2022-12-03T00:00:00Z","isDeprecated":true},"linuxRuntimeSettings":{"runtimeVersion":"dotnet|3.1","appInsightsSettings":{"isSupported":true},"remoteDebuggingSupported":false,"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.1.301"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"dotnet|3.1"},"supportedFunctionsExtensionVersions":["~3"],"endOfLifeDate":"2022-12-03T00:00:00Z","isDeprecated":true}}}]},{"displayText":".NET
+        Core 2","value":"dotnetcore2","minorVersions":[{"displayText":".NET Core 2.2","value":"2.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"2.2","appInsightsSettings":{"isSupported":true},"remoteDebuggingSupported":false,"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.2.207"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true},"supportedFunctionsExtensionVersions":["~2"]},"linuxRuntimeSettings":{"runtimeVersion":"dotnet|2.2","appInsightsSettings":{"isSupported":true},"remoteDebuggingSupported":false,"gitHubActionSettings":{"isSupported":true,"supportedVersion":"2.2.207"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"dotnet"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"dotnet|2.2"},"supportedFunctionsExtensionVersions":["~2"]}}}]},{"displayText":".NET
+        Framework 4","value":"dotnetframework4","minorVersions":[{"displayText":".NET
+        Framework 4.7","value":"4.7","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"4.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":false},"appSettingsDictionary":{},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true},"supportedFunctionsExtensionVersions":["~1"]}}}]}]}},{"id":null,"name":"node","type":"Microsoft.Web/functionAppStacks?stackOsType=All","properties":{"displayText":"Node.js","value":"node","preferredOs":"windows","majorVersions":[{"displayText":"Node.js
+        18","value":"18","minorVersions":[{"displayText":"Node.js 18 LTS","value":"18
+        LTS","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_NODE_DEFAULT_VERSION":"~18"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2025-04-30T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"Node|18","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"18.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|18"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2025-04-30T00:00:00Z"}}}]},{"displayText":"Node.js
+        16","value":"16","minorVersions":[{"displayText":"Node.js 16 LTS","value":"16
+        LTS","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~16","isPreview":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_NODE_DEFAULT_VERSION":"~16"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2023-09-11T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"Node|16","isPreview":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"16.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|16"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2023-09-11T00:00:00Z"}}}]},{"displayText":"Node.js
+        14","value":"14","minorVersions":[{"displayText":"Node.js 14 LTS","value":"14
+        LTS","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_NODE_DEFAULT_VERSION":"~14"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4","~3"],"endOfLifeDate":"2023-04-30T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"Node|14","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"14.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|14"},"supportedFunctionsExtensionVersions":["~4","~3"],"endOfLifeDate":"2023-04-30T00:00:00Z"}}}]},{"displayText":"Node.js
+        12","value":"12","minorVersions":[{"displayText":"Node.js 12 LTS","value":"12
+        LTS","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_NODE_DEFAULT_VERSION":"~12"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true},"supportedFunctionsExtensionVersions":["~3"],"endOfLifeDate":"2022-12-13T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"Node|12","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"12.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|12"},"supportedFunctionsExtensionVersions":["~3"],"endOfLifeDate":"2022-12-13T00:00:00Z"}}}]},{"displayText":"Node.js
+        10","value":"10","minorVersions":[{"displayText":"Node.js 10 LTS","value":"10
+        LTS","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~10","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_NODE_DEFAULT_VERSION":"~10"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true},"supportedFunctionsExtensionVersions":["~2","~3"],"endOfLifeDate":"2021-04-30T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"Node|10","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"10.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Node|10"},"supportedFunctionsExtensionVersions":["~2","~3"],"endOfLifeDate":"2021-04-30T00:00:00Z"}}}]},{"displayText":"Node.js
+        8","value":"8","minorVersions":[{"displayText":"Node.js 8 LTS","value":"8
+        LTS","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8.x"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_NODE_DEFAULT_VERSION":"~8"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true},"supportedFunctionsExtensionVersions":["~2"],"endOfLifeDate":"2019-12-31T00:00:00Z"}}}]},{"displayText":"Node.js
+        6","value":"6","minorVersions":[{"displayText":"Node.js 6 LTS","value":"6
+        LTS","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":false},"appSettingsDictionary":{"WEBSITE_NODE_DEFAULT_VERSION":"~6"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true},"supportedFunctionsExtensionVersions":["~1"],"endOfLifeDate":"2019-04-30T00:00:00Z"}}}]}]}},{"id":null,"name":"python","type":"Microsoft.Web/functionAppStacks?stackOsType=All","properties":{"displayText":"Python","value":"python","preferredOs":"linux","majorVersions":[{"displayText":"Python
+        3","value":"3","minorVersions":[{"displayText":"Python 3.10","value":"3.10","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Python|3.10","remoteDebuggingSupported":false,"isPreview":true,"isDefault":false,"isHidden":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.10"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"python"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Python|3.10"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2026-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.9","value":"3.9","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Python|3.9","remoteDebuggingSupported":false,"isPreview":false,"isDefault":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.9"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"python"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Python|3.9"},"supportedFunctionsExtensionVersions":["~4","~3"],"endOfLifeDate":"2025-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.8","value":"3.8","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Python|3.8","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.8"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"python"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Python|3.8"},"supportedFunctionsExtensionVersions":["~4","~3"],"endOfLifeDate":"2024-10-31T00:00:00Z"}}},{"displayText":"Python
+        3.7","value":"3.7","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Python|3.7","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.7"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"python"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Python|3.7"},"supportedFunctionsExtensionVersions":["~4","~3","~2"],"endOfLifeDate":"2023-06-30T00:00:00Z"}}},{"displayText":"Python
+        3.6","value":"3.6","stackSettings":{"linuxRuntimeSettings":{"runtimeVersion":"Python|3.6","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"3.6"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"python"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Python|3.6"},"supportedFunctionsExtensionVersions":["~2","~3"],"endOfLifeDate":"2022-09-30T00:00:00Z"}}}]}]}},{"id":null,"name":"java","type":"Microsoft.Web/functionAppStacks?stackOsType=All","properties":{"displayText":"Java","value":"java","preferredOs":"windows","majorVersions":[{"displayText":"Java
+        17","value":"17","minorVersions":[{"displayText":"Java 17","value":"17.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"17","isPreview":false,"isHidden":false,"isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"java"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"javaVersion":"17","netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2031-09-01T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"Java|17","isPreview":false,"isHidden":false,"isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"17"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"java"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Java|17"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2031-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        11","value":"11","minorVersions":[{"displayText":"Java 11","value":"11.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"java"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"javaVersion":"11","netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4","~3"],"endOfLifeDate":"2026-09-01T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"Java|11","isAutoUpdate":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"11"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"java"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Java|11"},"supportedFunctionsExtensionVersions":["~4","~3"],"endOfLifeDate":"2026-09-01T00:00:00Z"}}}]},{"displayText":"Java
+        8","value":"8","minorVersions":[{"displayText":"Java 8","value":"8.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"1.8","isAutoUpdate":true,"isDefault":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"java"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"javaVersion":"1.8","netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4","~3","~2"],"endOfLifeDate":"2025-03-01T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"Java|8","isAutoUpdate":true,"isDefault":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true,"supportedVersion":"8"},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"java"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"Java|8"},"supportedFunctionsExtensionVersions":["~4","~3"],"endOfLifeDate":"2025-03-01T00:00:00Z"}}}]}]}},{"id":null,"name":"powershell","type":"Microsoft.Web/functionAppStacks?stackOsType=All","properties":{"displayText":"PowerShell
+        Core","value":"powershell","preferredOs":"windows","majorVersions":[{"displayText":"PowerShell
+        7","value":"7","minorVersions":[{"displayText":"PowerShell 7.2","value":"7.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"7.2","isDefault":true,"isPreview":false,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"powershell"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"powerShellVersion":"7.2","netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2024-11-08T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"PowerShell|7.2","isDefault":true,"isPreview":false,"isHidden":false,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"powershell"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"PowerShell|7.2"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2024-11-08T00:00:00Z"}}},{"displayText":"PowerShell
+        7.0","value":"7.0","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~7","isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"powershell"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"powerShellVersion":"~7","netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4","~3"],"endOfLifeDate":"2022-12-03T00:00:00Z"},"linuxRuntimeSettings":{"runtimeVersion":"PowerShell|7","isAutoUpdate":true,"isPreview":false,"isDeprecated":true,"remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"powershell"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":"PowerShell|7"},"supportedFunctionsExtensionVersions":["~4"],"endOfLifeDate":"2022-12-03T00:00:00Z"}}}]},{"displayText":"PowerShell
+        Core 6","value":"6","minorVersions":[{"displayText":"PowerShell Core 6.2","value":"6.2","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"~6","remoteDebuggingSupported":false,"appInsightsSettings":{"isSupported":true},"gitHubActionSettings":{"isSupported":true},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"powershell"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"powerShellVersion":"~6"},"isDeprecated":true,"supportedFunctionsExtensionVersions":["~2","~3"],"endOfLifeDate":"2022-09-30T00:00:00Z"}}}]}]}},{"id":null,"name":"custom","type":"Microsoft.Web/functionAppStacks?stackOsType=All","properties":{"displayText":"Custom
+        Handler","value":"custom","preferredOs":"windows","majorVersions":[{"displayText":"Custom
+        Handler","value":"custom","minorVersions":[{"displayText":"Custom Handler","value":"custom","stackSettings":{"windowsRuntimeSettings":{"runtimeVersion":"custom","appInsightsSettings":{"isSupported":true},"remoteDebuggingSupported":false,"gitHubActionSettings":{"isSupported":false},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"custom"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":true,"netFrameworkVersion":"v6.0"},"supportedFunctionsExtensionVersions":["~4","~3","~2"]},"linuxRuntimeSettings":{"runtimeVersion":"","isPreview":false,"appInsightsSettings":{"isSupported":true},"remoteDebuggingSupported":false,"gitHubActionSettings":{"isSupported":false},"appSettingsDictionary":{"FUNCTIONS_WORKER_RUNTIME":"custom"},"siteConfigPropertiesDictionary":{"use32BitWorkerProcess":false,"linuxFxVersion":""},"supportedFunctionsExtensionVersions":["~4","~3","~2"]}}}]}]}}],"nextLink":null,"id":null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '23882'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:50:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002?api-version=2022-09-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002","name":"clitest000002","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":"2023-01-31T18:46:15.6289960Z","key2":"2023-01-31T18:46:15.6289960Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":false,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-31T18:46:16.0040057Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2023-01-31T18:46:16.0040057Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2023-01-31T18:46:15.3789656Z","primaryEndpoints":{"blob":"https://clitest000002.blob.core.windows.net/","queue":"https://clitest000002.queue.core.windows.net/","table":"https://clitest000002.table.core.windows.net/","file":"https://clitest000002.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1270'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:50:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2022-09-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2023-01-31T18:46:15.6289960Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2023-01-31T18:46:15.6289960Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:50:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-mgmt-appcontainers/1.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004?api-version=2022-03-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004","name":"containerappmanagedenvironment000004","type":"Microsoft.App/managedEnvironments","location":"centraluseuap","systemData":{"createdBy":"kaibocai@microsoft.com","createdByType":"User","createdAt":"2023-01-31T18:47:15.3722307","lastModifiedBy":"kaibocai@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-01-31T18:47:15.3722307"},"properties":{"provisioningState":"Succeeded","defaultDomain":"politecliff-8f7a0714.centraluseuap.azurecontainerapps.io","staticIp":"20.228.50.253","appLogsConfiguration":{"destination":"log-analytics","logAnalyticsConfiguration":{"customerId":"6b942a94-14c9-413d-ad0f-6fc9a402ce9e"}},"zoneRedundant":false}}'
+    headers:
+      api-supported-versions:
+      - 2022-01-01-preview, 2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview,
+        2023-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '831'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:50:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"kind": "functionapp", "location": "francecentral", "properties": {"reserved":
+      false, "isXenon": false, "hyperV": false, "siteConfig": {"netFrameworkVersion":
+      "v4.6", "appSettings": [{"name": "FUNCTIONS_WORKER_RUNTIME", "value": "dotnet"},
+      {"name": "FUNCTIONS_EXTENSION_VERSION", "value": "~4"}, {"name": "AzureWebJobsStorage",
+      "value": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey=="},
+      {"name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", "value": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey=="},
+      {"name": "WEBSITE_CONTENTSHARE", "value": "functionappwindowsruntime000003a753c2453410"}],
+      "use32BitWorkerProcess": true, "localMySqlEnabled": false, "http20Enabled":
+      true}, "scmSiteAlsoStopped": false, "httpsOnly": false, "managedEnvironment":
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.App/managedEnvironments/containerappmanagedenvironment000004"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1079'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-web/7.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/functionappwindowsruntime000003?api-version=2022-03-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/functionappwindowsruntime000003","name":"functionappwindowsruntime000003","type":"Microsoft.Web/sites","kind":"functionapp","location":"francecentral","properties":{"name":"functionappwindowsruntime000003","state":"Running","hostNames":["functionappwindowsruntime000003.azurewebsites.net"],"webSpace":"clitest.rg000001-FranceCentralwebspace","selfLink":"https://waws-prod-par-017.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/clitest.rg000001-FranceCentralwebspace/sites/functionappwindowsruntime000003","repositorySiteName":"functionappwindowsruntime000003","owner":null,"usageState":"Normal","enabled":true,"adminEnabled":true,"enabledHostNames":["functionappwindowsruntime000003.azurewebsites.net","functionappwindowsruntime000003.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[{"name":"LinuxFxVersion","value":""},{"name":"WindowsFxVersion","value":null}],"appSettings":null},"availabilityState":"Normal","sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"functionappwindowsruntime000003.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Standard"},{"name":"functionappwindowsruntime000003.scm.azurewebsites.net","sslState":"Disabled","ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":"NotConfigured","hostType":"Repository"}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/serverfarms/FranceCentralPlan","reserved":false,"isXenon":false,"hyperV":false,"lastModifiedTimeUtc":"2023-01-31T18:50:37.99","storageRecoveryDefaultState":"Running","contentAvailabilityState":"Normal","runtimeAvailabilityState":"Normal","dnsConfiguration":{},"vnetRouteAllEnabled":false,"containerAllocationSubnet":null,"useContainerLocalhostBindings":null,"vnetImagePullEnabled":false,"vnetContentShareEnabled":false,"siteConfig":{"numberOfWorkers":1,"defaultDocuments":null,"netFrameworkVersion":null,"phpVersion":null,"pythonVersion":null,"nodeVersion":null,"powerShellVersion":null,"linuxFxVersion":"","windowsFxVersion":null,"windowsConfiguredStacks":null,"requestTracingEnabled":null,"remoteDebuggingEnabled":null,"remoteDebuggingVersion":null,"httpLoggingEnabled":null,"azureMonitorLogCategories":null,"acrUseManagedIdentityCreds":false,"acrUserManagedIdentityID":null,"logsDirectorySizeLimit":null,"detailedErrorLoggingEnabled":null,"publishingUsername":null,"publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":null,"use32BitWorkerProcess":null,"webSocketsEnabled":null,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":null,"managedPipelineMode":null,"virtualApplications":null,"winAuthAdminState":null,"winAuthTenantState":null,"customAppPoolIdentityAdminState":null,"customAppPoolIdentityTenantState":null,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":null,"routingRules":null,"experiments":null,"limits":null,"autoHealEnabled":null,"autoHealRules":null,"tracingOptions":null,"vnetName":null,"vnetRouteAllEnabled":null,"vnetPrivatePortsCount":null,"publicNetworkAccess":null,"cors":null,"push":null,"apiDefinition":null,"apiManagementConfig":null,"autoSwapSlotName":null,"localMySqlEnabled":null,"managedServiceIdentityId":null,"xManagedServiceIdentityId":null,"keyVaultReferenceIdentity":null,"ipSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"ipSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictions":[{"ipAddress":"Any","action":"Allow","priority":2147483647,"name":"Allow
+        all","description":"Allow all access"}],"scmIpSecurityRestrictionsDefaultAction":null,"scmIpSecurityRestrictionsUseMain":null,"http20Enabled":false,"minTlsVersion":null,"minTlsCipherSuite":null,"supportedTlsCipherSuites":null,"scmMinTlsVersion":null,"ftpsState":null,"preWarmedInstanceCount":null,"functionAppScaleLimit":0,"elasticWebAppScaleLimit":null,"healthCheckPath":null,"fileChangeAuditEnabled":null,"functionsRuntimeScaleMonitoringEnabled":null,"websiteTimeZone":null,"minimumElasticInstanceCount":0,"azureStorageAccounts":null,"http20ProxyFlag":null,"sitePort":null,"antivirusScanEnabled":null,"storageType":null},"deploymentId":"functionappwindowsruntime000003","slotName":null,"trafficManagerHostNames":null,"sku":"Dynamic","scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"clientAffinityEnabled":false,"clientCertEnabled":false,"clientCertMode":"Required","clientCertExclusionPaths":null,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"customDomainVerificationId":"6A108451B17002C41839DE6A6A6C2437FFFD9613ED171E8F4EDCA510BE7218C7","kind":"functionapp","inboundIpAddress":"20.43.43.34","possibleInboundIpAddresses":"20.43.43.34","ftpUsername":"functionappwindowsruntime000003\\$functionappwindowsruntime000003","ftpsHostName":"ftps://waws-prod-par-017.ftp.azurewebsites.windows.net/site/wwwroot","outboundIpAddresses":"20.74.32.117,20.74.33.188,20.74.33.193,20.74.33.253,20.74.34.55,20.74.34.65,20.43.43.34","possibleOutboundIpAddresses":"20.74.32.117,20.74.33.188,20.74.33.193,20.74.33.253,20.74.34.55,20.74.34.65,20.74.34.69,20.74.34.108,20.74.34.132,20.74.34.139,20.74.34.143,20.74.34.145,20.74.34.150,20.74.34.161,20.74.34.162,20.74.34.176,20.74.34.185,20.74.34.194,20.43.43.34","containerSize":1536,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-par-017","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"clitest.rg000001","defaultHostName":"functionappwindowsruntime000003.azurewebsites.net","slotSwapStatus":null,"httpsOnly":false,"redundancyMode":"None","inProgressOperationId":null,"geoDistributions":null,"privateEndpointConnections":null,"publicNetworkAccess":null,"buildVersion":null,"targetBuildVersion":null,"migrationState":null,"eligibleLogCategories":"FunctionAppLogs","storageAccountRequired":false,"virtualNetworkSubnetId":null,"keyVaultReferenceIdentity":"SystemAssigned","defaultHostNameScope":"Global","privateLinkIdentifiers":null}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '6672'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:51:04 GMT
+      etag:
+      - '"1D935A4E99E13A0"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '499'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "francecentral", "kind": "web", "properties": {"Application_Type":
+      "web"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '87'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-applicationinsights/1.0.0 Python/3.8.10
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Insights/components/functionappwindowsruntime000003?api-version=2015-05-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/microsoft.insights/components/functionappwindowsruntime000003\",\r\n
+        \ \"name\": \"functionappwindowsruntime000003\",\r\n  \"type\": \"microsoft.insights/components\",\r\n
+        \ \"location\": \"francecentral\",\r\n  \"tags\": {},\r\n  \"kind\": \"web\",\r\n
+        \ \"etag\": \"\\\"75012f25-0000-0e00-0000-63d9631a0000\\\"\",\r\n  \"properties\":
+        {\r\n    \"ApplicationId\": \"functionappwindowsruntime000003\",\r\n    \"AppId\":
+        \"07629906-0129-440b-a77e-dd232d826ea7\",\r\n    \"Application_Type\": \"web\",\r\n
+        \   \"Flow_Type\": null,\r\n    \"Request_Source\": null,\r\n    \"InstrumentationKey\":
+        \"ba0156f8-91be-4db1-902a-d019eb06664c\",\r\n    \"ConnectionString\": \"InstrumentationKey=ba0156f8-91be-4db1-902a-d019eb06664c;IngestionEndpoint=https://francecentral-0.in.applicationinsights.azure.com/;LiveEndpoint=https://francecentral.livediagnostics.monitor.azure.com/\",\r\n
+        \   \"Name\": \"functionappwindowsruntime000003\",\r\n    \"CreationDate\":
+        \"2023-01-31T18:51:06.4137239+00:00\",\r\n    \"TenantId\": \"7809c3da-98dc-4171-818c-9da39a077f39\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"SamplingPercentage\": null,\r\n
+        \   \"RetentionInDays\": 90,\r\n    \"IngestionMode\": \"ApplicationInsights\",\r\n
+        \   \"publicNetworkAccessForIngestion\": \"Enabled\",\r\n    \"publicNetworkAccessForQuery\":
+        \"Enabled\",\r\n    \"Ver\": \"v2\"\r\n  }\r\n}"
+    headers:
+      access-control-expose-headers:
+      - Request-Context
+      cache-control:
+      - no-cache
+      content-length:
+      - '1322'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 31 Jan 2023 18:51:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      request-context:
+      - appId=cid-v1:7f83c1fe-8c94-4d55-9337-4ddc696f61ed
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-web/7.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/functionappwindowsruntime000003/config/appsettings/list?api-version=2022-03-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/functionappwindowsruntime000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"France
+        Central","properties":{"FUNCTIONS_WORKER_RUNTIME":"dotnet","FUNCTIONS_EXTENSION_VERSION":"~4","AzureWebJobsStorage":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==","WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==","WEBSITE_CONTENTSHARE":"functionappwindowsruntime000003a753c2453410"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '740'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:51:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"FUNCTIONS_WORKER_RUNTIME": "dotnet", "FUNCTIONS_EXTENSION_VERSION":
+      "~4", "AzureWebJobsStorage": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==",
+      "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==",
+      "WEBSITE_CONTENTSHARE": "functionappwindowsruntime000003a753c2453410", "APPINSIGHTS_INSTRUMENTATIONKEY":
+      "ba0156f8-91be-4db1-902a-d019eb06664c"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - functionapp create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '567'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -n -c -s --environment --os-type --functions-version
+      User-Agent:
+      - AZURECLI/2.44.1 azsdk-python-azure-mgmt-web/7.0.0 Python/3.8.10 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/functionappwindowsruntime000003/config/appsettings?api-version=2022-03-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Web/sites/functionappwindowsruntime000003/config/appsettings","name":"appsettings","type":"Microsoft.Web/sites/config","location":"France
+        Central","properties":{"FUNCTIONS_WORKER_RUNTIME":"dotnet","FUNCTIONS_EXTENSION_VERSION":"~4","AzureWebJobsStorage":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==","WEBSITE_CONTENTAZUREFILECONNECTIONSTRING":"DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=clitest000002;AccountKey=veryFakedStorageAccountKey==","WEBSITE_CONTENTSHARE":"functionappwindowsruntime000003a753c2453410","APPINSIGHTS_INSTRUMENTATIONKEY":"ba0156f8-91be-4db1-902a-d019eb06664c"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '812'
+      content-type:
+      - application/json
+      date:
+      - Tue, 31 Jan 2023 18:51:14 GMT
+      etag:
+      - '"1D935A4E99E13A0"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-aspnet-version:
+      - 4.0.30319
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
**Related command**
Add a warning message and ignore the VNET and SUBNET parameters, when managed environement and VNET or SUBNET parameter are both provided when create a function app using `az functionapp create` command. 

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

For project Centauri, when customer provide the managed environment while creating function app, they are supposed to not provide any VNET and SUBNET parameters. 
If above happen, we add a warning message and ignore the VNET and SUBNET parameters. 

**Testing Guide**
<!--Example commands with explanations.-->
To be updated. 


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
