### PR TITLE
[App Service] `az functionapp create`: Add check for vnet param

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3500,6 +3500,9 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
     client = web_client_factory(cmd.cli_ctx)
 
     if vnet or subnet:
+        if environment is not None:
+            raise ArgumentUsageError('vnet paramter and managed environment parameter canot be passed in at the same time', 
+            'This function app is created in an App Environment. Go to App environment to configure Networking')
         if plan:
             if is_valid_resource_id(plan):
                 parse_result = parse_resource_id(plan)


### PR DESCRIPTION
**Related command**
Update vnet logics for project centauri using functionapp commands:
1. when create functionapp using `az functionapp create`, if vnet, subnet paramters and manged enviornment paramter are both passed in, then raise an error with help message and stop proceed. 

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

For project Centauri, when customer provide the managed environment while creating function app, they are supposed config VNET using functionapp command instead, they should config vnet when create the container app enviornment.
If above happen, we add a error message and stop proceed. 

**Testing Guide**
<!--Example commands with explanations.-->
1. create function app using `az functionapp create` with both vnet, subnet parameters and managed environment paramter, expect failure in this case. 


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
