### PR TITLE
update vnet logics - update delete fuction logics

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -129,6 +129,22 @@ def validate_app_exists(cmd, namespace):
         raise ResourceNotFoundError("'{}' app not found in ResourceGroup '{}'".format(app, resource_group_name))
 
 
+def validate_functionapp_on_containerapp_vnet_add(cmd, namespace):
+    validate_functionapp_on_containerapp_vnet(cmd, namespace)
+    validate_add_vnet(cmd, namespace)
+
+
+def validate_functionapp_on_containerapp_vnet(cmd, namespace):
+    resource_group_name = namespace.resource_group_name
+    name = namespace.name
+    slot = namespace.slot
+    function_app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
+    if function_app.managed_environment_id is not None:
+        raise ValidationError(
+            'Unspported operation on function app.',
+            'Please set vNet Configuration for the function app at Container app environment level')
+
+
 def validate_add_vnet(cmd, namespace):
     from azure.core.exceptions import ResourceNotFoundError as ResNotFoundError
 
@@ -429,3 +445,14 @@ def validate_app_is_functionapp(cmd, namespace):
         raise ValidationError(f"App '{name}' in group '{rg}' is a logic app.")
     if is_webapp(app):
         raise ValidationError(f"App '{name}' in group '{rg}' is a web app.")
+
+
+def validate_centauri_delete_function(cmd, namespace):
+    resource_group_name = namespace.resource_group_name
+    name = namespace.name
+    slot = namespace.slot
+    function_app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
+    if function_app.managed_environment_id is not None:
+        raise ValidationError(
+            "Invalid Operation. This function is currently present in your image",
+            "Please modify your image to remove the function and provide an updated image.")

--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -141,8 +141,8 @@ def validate_functionapp_on_containerapp_vnet(cmd, namespace):
     function_app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
     if function_app.managed_environment_id is not None:
         raise ValidationError(
-            'Unspported operation on function app.',
-            'Please set vNet Configuration for the function app at Container app environment level')
+            'Unsupported operation on function app.',
+            'Please set virtual network configuration for the function app at Container app environment level.')
 
 
 def validate_add_vnet(cmd, namespace):

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -11,7 +11,8 @@ from ._client_factory import cf_web_client, cf_plans, cf_webapps
 from ._validators import (validate_onedeploy_params, validate_staticsite_link_function, validate_staticsite_sku,
                           validate_vnet_integration, validate_asp_create, validate_functionapp_asp_create,
                           validate_webapp_up, validate_app_exists, validate_add_vnet, validate_app_is_functionapp,
-                          validate_app_is_webapp)
+                          validate_app_is_webapp, validate_functionapp_on_containerapp_vnet,
+                          validate_functionapp_on_containerapp_vnet_add, validate_centauri_delete_function)
 
 
 def output_slots_in_table(slots):
@@ -292,9 +293,9 @@ def load_command_table(self, _):
         g.custom_command('remove', 'remove_vnet_integration')
 
     with self.command_group('functionapp vnet-integration') as g:
-        g.custom_command('add', 'add_functionapp_vnet_integration', validator=validate_add_vnet, exception_handler=ex_handler_factory())
-        g.custom_command('list', 'list_vnet_integration')
-        g.custom_command('remove', 'remove_vnet_integration')
+        g.custom_command('add', 'add_functionapp_vnet_integration', validator=validate_functionapp_on_containerapp_vnet_add, exception_handler=ex_handler_factory())
+        g.custom_command('list', 'list_functionapp_vnet_integration', validator=validate_functionapp_on_containerapp_vnet, exception_handler=ex_handler_factory())
+        g.custom_command('remove', 'remove_functionapp_vnet_integration', validator=validate_functionapp_on_containerapp_vnet, exception_handler=ex_handler_factory())
 
     with self.command_group('appservice plan', appservice_plan_sdk) as g:
         g.custom_command('create', 'create_app_service_plan', supports_no_wait=True,
@@ -412,7 +413,7 @@ def load_command_table(self, _):
 
     with self.command_group('functionapp function') as g:
         g.custom_command('show', 'show_function')  # pylint: disable=show-command
-        g.custom_command('delete', 'delete_function')
+        g.custom_command('delete', 'delete_function', validator=validate_centauri_delete_function, exception_handler=ex_handler_factory())
         g.custom_command('list', 'list_functions')
 
     with self.command_group('functionapp function keys') as g:

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3500,6 +3500,10 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
     client = web_client_factory(cmd.cli_ctx)
 
     if vnet or subnet:
+        if environment is not None:
+            raise ArgumentUsageError(
+                "Unspported operation on function app.",
+                "Please set vNet Configuration for the function app at Container app environment level.")
         if plan:
             if is_valid_resource_id(plan):
                 parse_result = parse_resource_id(plan)
@@ -4140,6 +4144,10 @@ def remove_hc(cmd, resource_group_name, name, namespace, hybrid_connection, slot
     return return_hc
 
 
+def list_functionapp_vnet_integration(cmd, name, resource_group_name, slot=None):
+    return list_vnet_integration(cmd, name, resource_group_name, slot=None)
+
+
 def list_vnet_integration(cmd, name, resource_group_name, slot=None):
     client = web_client_factory(cmd.cli_ctx)
     if slot is None:
@@ -4316,6 +4324,10 @@ def _validate_subnet(cli_ctx, subnet, vnet, resource_group_name):
         name=vnet_id_parts['name'],
         child_type_1='subnets',
         child_name_1=subnet)
+
+
+def remove_functionapp_vnet_integration(cmd, name, resource_group_name, slot=None):
+    return remove_vnet_integration(cmd, name, resource_group_name, slot)
 
 
 def remove_vnet_integration(cmd, name, resource_group_name, slot=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3502,8 +3502,8 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
     if vnet or subnet:
         if environment is not None:
             raise ArgumentUsageError(
-                "Unspported operation on function app.",
-                "Please set vNet Configuration for the function app at Container app environment level.")
+                "Unsupported operation on function app.",
+                "Please set virtual network configuration for the function app at Container app environment level.")
         if plan:
             if is_valid_resource_id(plan):
                 parse_result = parse_resource_id(plan)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -581,6 +581,149 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
         with self.assertRaises(ArgumentUsageError):
             self.cmd('functionapp create -g {} -n {} -c {} -s {} --environment {} --runtime dotnet --functions-version 4'
                     .format(resource_group, functionapp_name, WINDOWS_ASP_LOCATION_FUNCTIONAPP, storage_account, managed_environment_name))
+            
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_create_with_appcontainer_managed_environment_vnet_config_error(self, resource_group, storage_account):
+        functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
+        managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
+        plan_name = self.create_random_name('functionappplan', 40)
+        subnet_name = self.create_random_name('swiftsubnet', 24)
+        vnet_name = self.create_random_name('swiftname', 24)
+
+        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
+        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
+                     JMESPathCheck('name', managed_environment_name),
+                     JMESPathCheck('resourceGroup', resource_group),
+                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
+
+        self.cmd('network vnet create -g {} -n {} --address-prefix 10.0.0.0/16 --subnet-name {} --subnet-prefix 10.0.0.0/24'.format(
+            resource_group, vnet_name, subnet_name))
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
+
+        with self.assertRaises(ArgumentUsageError):
+            self.cmd('functionapp create -g {} -n {} -p {} -s {} --vnet {} --subnet {}  --environment {} --runtime dotnet --functions-version 4'
+                    .format(resource_group, functionapp_name, plan_name, storage_account, vnet_name, subnet_name, managed_environment_name))
+            
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_create_with_appcontainer_managed_environment_add_vnet_error(self, resource_group, storage_account):
+        functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
+        managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
+        plan_name = self.create_random_name('functionappplan', 40)
+        subnet_name = self.create_random_name('swiftsubnet', 24)
+        vnet_name = self.create_random_name('swiftname', 24)
+
+        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
+        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
+                     JMESPathCheck('name', managed_environment_name),
+                     JMESPathCheck('resourceGroup', resource_group),
+                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
+
+        self.cmd('network vnet create -g {} -n {} --address-prefix 10.0.0.0/16 --subnet-name {} --subnet-prefix 10.0.0.0/24'.format(
+            resource_group, vnet_name, subnet_name))
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
+        self.cmd(
+            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+                     JMESPathCheck('state', 'Running'),
+                     JMESPathCheck('name', functionapp_name),
+                     JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
+
+
+        with self.assertRaises(ValidationError):
+            self.cmd('functionapp vnet-integration add -g {} -n {} --vnet {} --subnet {}'
+            .format(resource_group, functionapp_name, vnet_name, subnet_name))
+
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_create_with_appcontainer_managed_environment_remove_vnet_error(self, resource_group, storage_account):
+        functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
+        managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
+        plan_name = self.create_random_name('functionappplan', 40)
+        subnet_name = self.create_random_name('swiftsubnet', 24)
+        vnet_name = self.create_random_name('swiftname', 24)
+
+        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
+        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
+                     JMESPathCheck('name', managed_environment_name),
+                     JMESPathCheck('resourceGroup', resource_group),
+                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
+
+        self.cmd('network vnet create -g {} -n {} --address-prefix 10.0.0.0/16 --subnet-name {} --subnet-prefix 10.0.0.0/24'.format(
+            resource_group, vnet_name, subnet_name))
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
+        self.cmd(
+            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+                     JMESPathCheck('state', 'Running'),
+                     JMESPathCheck('name', functionapp_name),
+                     JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
+        with self.assertRaises(ValidationError):
+            self.cmd('functionapp vnet-integration remove -g {} -n {}'.format(
+                resource_group, functionapp_name), expect_failure=True)
+
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_create_with_appcontainer_managed_environment_list_vnet_error(self, resource_group, storage_account):
+        functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
+        managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
+        plan_name = self.create_random_name('functionappplan', 40)
+        subnet_name = self.create_random_name('swiftsubnet', 24)
+        vnet_name = self.create_random_name('swiftname', 24)
+
+        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
+        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
+                     JMESPathCheck('name', managed_environment_name),
+                     JMESPathCheck('resourceGroup', resource_group),
+                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
+
+        self.cmd('network vnet create -g {} -n {} --address-prefix 10.0.0.0/16 --subnet-name {} --subnet-prefix 10.0.0.0/24'.format(
+            resource_group, vnet_name, subnet_name))
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
+        self.cmd(
+            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+                     JMESPathCheck('state', 'Running'),
+                     JMESPathCheck('name', functionapp_name),
+                     JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
+
+        with self.assertRaises(ValidationError):
+            self.cmd('functionapp vnet-integration list -g {} -n {}'.format(
+                resource_group, functionapp_name), expect_failure=True)
+            
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_delete_functions(self, resource_group, storage_account):
+        functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
+        function_name = self.create_random_name('functionappwindowsruntimefunctions', 40)
+        managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
+        plan_name = self.create_random_name('functionappplan', 40)
+
+        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
+        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
+                     JMESPathCheck('name', managed_environment_name),
+                     JMESPathCheck('resourceGroup', resource_group),
+                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
+
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
+
+        self.cmd(
+            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+                     JMESPathCheck('state', 'Running'),
+                     JMESPathCheck('name', functionapp_name),
+                     JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
+
+
+        with self.assertRaises(ValidationError):
+            self.cmd('functionapp function delete -g {} -n {} --function-name {}'
+            .format(resource_group, functionapp_name, function_name))
 
 class FunctionAppOnWindowsWithRuntime(ScenarioTest):
     @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -587,7 +587,6 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
     def test_functionapp_create_with_appcontainer_managed_environment_vnet_config_error(self, resource_group, storage_account):
         functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
         managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
-        plan_name = self.create_random_name('functionappplan', 40)
         subnet_name = self.create_random_name('swiftsubnet', 24)
         vnet_name = self.create_random_name('swiftname', 24)
 
@@ -599,19 +598,16 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
 
         self.cmd('network vnet create -g {} -n {} --address-prefix 10.0.0.0/16 --subnet-name {} --subnet-prefix 10.0.0.0/24'.format(
             resource_group, vnet_name, subnet_name))
-        self.cmd(
-            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
 
         with self.assertRaises(ArgumentUsageError):
-            self.cmd('functionapp create -g {} -n {} -p {} -s {} --vnet {} --subnet {}  --environment {} --runtime dotnet --functions-version 4'
-                    .format(resource_group, functionapp_name, plan_name, storage_account, vnet_name, subnet_name, managed_environment_name))
+            self.cmd('functionapp create -g {} -n {} -s {} --vnet {} --subnet {}  --environment {} --runtime dotnet --functions-version 4'
+                    .format(resource_group, functionapp_name, storage_account, vnet_name, subnet_name, managed_environment_name))
             
     @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
     @StorageAccountPreparer()
     def test_functionapp_create_with_appcontainer_managed_environment_add_vnet_error(self, resource_group, storage_account):
         functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
         managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
-        plan_name = self.create_random_name('functionappplan', 40)
         subnet_name = self.create_random_name('swiftsubnet', 24)
         vnet_name = self.create_random_name('swiftname', 24)
 
@@ -623,11 +619,10 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
 
         self.cmd('network vnet create -g {} -n {} --address-prefix 10.0.0.0/16 --subnet-name {} --subnet-prefix 10.0.0.0/24'.format(
             resource_group, vnet_name, subnet_name))
+
         self.cmd(
-            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
-        self.cmd(
-            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
-            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+            'functionapp create -g {} -n {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, storage_account, managed_environment_name)).assert_with_checks([
                      JMESPathCheck('state', 'Running'),
                      JMESPathCheck('name', functionapp_name),
                      JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
@@ -642,7 +637,6 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
     def test_functionapp_create_with_appcontainer_managed_environment_remove_vnet_error(self, resource_group, storage_account):
         functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
         managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
-        plan_name = self.create_random_name('functionappplan', 40)
         subnet_name = self.create_random_name('swiftsubnet', 24)
         vnet_name = self.create_random_name('swiftname', 24)
 
@@ -654,11 +648,10 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
 
         self.cmd('network vnet create -g {} -n {} --address-prefix 10.0.0.0/16 --subnet-name {} --subnet-prefix 10.0.0.0/24'.format(
             resource_group, vnet_name, subnet_name))
+
         self.cmd(
-            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
-        self.cmd(
-            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
-            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+            'functionapp create -g {} -n {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, storage_account, managed_environment_name)).assert_with_checks([
                      JMESPathCheck('state', 'Running'),
                      JMESPathCheck('name', functionapp_name),
                      JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
@@ -671,7 +664,6 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
     def test_functionapp_create_with_appcontainer_managed_environment_list_vnet_error(self, resource_group, storage_account):
         functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
         managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
-        plan_name = self.create_random_name('functionappplan', 40)
         subnet_name = self.create_random_name('swiftsubnet', 24)
         vnet_name = self.create_random_name('swiftname', 24)
 
@@ -683,11 +675,10 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
 
         self.cmd('network vnet create -g {} -n {} --address-prefix 10.0.0.0/16 --subnet-name {} --subnet-prefix 10.0.0.0/24'.format(
             resource_group, vnet_name, subnet_name))
+
         self.cmd(
-            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
-        self.cmd(
-            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
-            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+            'functionapp create -g {} -n {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, storage_account, managed_environment_name)).assert_with_checks([
                      JMESPathCheck('state', 'Running'),
                      JMESPathCheck('name', functionapp_name),
                      JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
@@ -702,7 +693,6 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
         functionapp_name = self.create_random_name('functionappwindowsruntime', 40)
         function_name = self.create_random_name('functionappwindowsruntimefunctions', 40)
         managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
-        plan_name = self.create_random_name('functionappplan', 40)
 
         self.cmd('containerapp env create --name {} --resource-group {} --location {}'
         .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
@@ -711,11 +701,8 @@ class FunctionAppManagedEnvironment(LiveScenarioTest):
                      JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
 
         self.cmd(
-            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
-
-        self.cmd(
-            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
-            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+            'functionapp create -g {} -n {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, storage_account, managed_environment_name)).assert_with_checks([
                      JMESPathCheck('state', 'Running'),
                      JMESPathCheck('name', functionapp_name),
                      JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])


### PR DESCRIPTION
**Related command**

#### 1. Update vnet logics for project centauri using functionapp commands:

- when create functionapp using `az functionapp create`, if vnet, subnet paramters and manged enviornment paramter are both passed in, then raise an error with help message and stop proceed. 

#### 2. Update vnet logics for project centauri using functionapp commands:

- when running `az functionapp vnet-integration list` command on a functionapp that's on container app enviornment, raise an error with help message and stop proceed. 

- when running `az functionapp vnet-integration add` command on a functionapp that's on container app enviornment, raise an error with help message and stop proceed. 

- when running `az functionapp vnet-integration remove` command on a functionapp that's on container app enviornment, raise an error with help message and stop proceed. 

#### 3. Update delete function logics for project centauri using functionapp commands:

- when running `az functionapp function delete` command on a functionapp that's on container app enviornment, raise an error with help message and stop proceed. 



**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

1. For project Centauri, when customer provide the managed environment while creating function app, it's not supported, they should config vnet when create the container app enviornment. If above happen, we add a error message and stop proceed. 

2. For project Centauri, when customer try to update the vnet configuration of a function app, it's not supported, they should config vnet when create the container app enviornment. If above happen, we add a error message and stop proceed. 

3. For project Centauri, when customer try to delete functions of a function app, it's not supported, they should modify their function app image. If above happen, we add a error message and stop proceed. 

**Testing Guide**
<!--Example commands with explanations.-->
#### 1. Update vnet logics for project centauri using functionapp commands:

- create function app using `az functionapp create` with both vnet, subnet parameters and managed environment paramter, expect failure in this case. 

#### 2. Update vnet logics for project centauri using functionapp commands:

- create a function app on container app environment, and then trying to add vnet using `az functionapp vnet-integration add` should fail. Currently, this test case is failing, it should pass once the python sdk is updated. https://github.com/Azure/sdk-release-request/issues/3916

#### 3. Update delete function logics for project centauri using functionapp commands:

- create a function app on container app environment, and then trying to delete function using command `az functionapp function delete` should fail. Currently, this test case is failing, it should pass once the python sdk is updated. https://github.com/Azure/sdk-release-request/issues/3916

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
