### PR TITLE
Fix workaround exception

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -174,7 +174,11 @@ def show_raw_functionapp(cmd, resource_group_name, name):
 
 def is_centauri_functionapp(cmd, resource_group, name):
     function_app = show_raw_functionapp(cmd, resource_group, name)
-    return function_app["properties"]["managedEnvironmentId"] is not None
+    try:
+        managedEnvironmentId = function_app["properties"]["managedEnvironmentId"]
+    except Exception as ex:
+        return False
+    return managedEnvironmentId is not None
 
 
 def _list_app(cli_ctx, resource_group_name=None):


### PR DESCRIPTION
For normal function app which doesn't have `managedEnvironmentId` property, query it's value by `function_app["properties"]["managedEnvironmentId"]` will throw out exception. Update the workaround so when exception throw out we know it's not a centauri app. 