### PR TITLE
<Do not merge> add more regions for function-apps forto flex-consumption sku and update zip url for intent based deployment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -5071,7 +5071,38 @@ def list_flexconsumption_locations(cmd):
         },
         {
             "name": "northeurope"
-        }
+        },
+        {
+            "name": "eastasia"
+        },
+        {
+            "name": "centralus"
+        },
+        {
+            "name": "uksouth"
+        },
+        {
+            "name": "eastus2"
+        },
+        {
+            "name": "australiaeast"
+        },
+        {
+            "name": "westus3"
+        },
+        {
+            "name": "southcentralus"
+        },
+        {
+            "name": "swedencentral"
+        },
+        {
+            "name": "southeastasia"
+        },
+        {
+            "name": "northcentralus(stage)"
+        },
+
     ]
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -670,7 +670,7 @@ def enable_zip_deploy_flex(cmd, resource_group_name, name, src, timeout=None, sl
     except ValueError:
         raise ResourceNotFoundError('Failed to fetch scm url for function app')
 
-    zip_url = scm_url + '/api/Deploy/Zip?RemoteBuild={}&Deployer=az_cli'.format(build_remote)
+    zip_url = scm_url + '/api/publish?RemoteBuild={}&Deployer=az_cli'.format(build_remote)
     deployment_status_url = scm_url + '/api/deployments/latest'
 
     additional_headers = {"Content-Type": "application/zip", "Cache-Control": "no-cache"}
@@ -715,7 +715,7 @@ def enable_zip_deploy(cmd, resource_group_name, name, src, timeout=None, slot=No
     client = web_client_factory(cmd.cli_ctx)
     app = client.web_apps.get(resource_group_name, name)
     deployer = '&Deployer=az_cli_functions' if is_functionapp(app) else ''
-    zip_url = scm_url + '/api/zipdeploy?isAsync=true' + deployer
+    zip_url = scm_url + '/api/publish/zipdeploy?isAsync=true' + deployer
     deployment_status_url = scm_url + '/api/deployments/latest'
 
     additional_headers = {"Content-Type": "application/octet-stream", "Cache-Control": "no-cache"}
@@ -5083,6 +5083,9 @@ def list_flexconsumption_locations(cmd):
         },
         {
             "name": "eastus2"
+        },
+        {
+            "name": "eastus2euap"
         },
         {
             "name": "australiaeast"

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -715,7 +715,7 @@ def enable_zip_deploy(cmd, resource_group_name, name, src, timeout=None, slot=No
     client = web_client_factory(cmd.cli_ctx)
     app = client.web_apps.get(resource_group_name, name)
     deployer = '&Deployer=az_cli_functions' if is_functionapp(app) else ''
-    zip_url = scm_url + '/api/publish/zipdeploy?isAsync=true' + deployer
+    zip_url = scm_url + '/api/zipdeploy?isAsync=true' + deployer
     deployment_status_url = scm_url + '/api/deployments/latest'
 
     additional_headers = {"Content-Type": "application/octet-stream", "Cache-Control": "no-cache"}
@@ -5089,6 +5089,9 @@ def list_flexconsumption_locations(cmd):
         },
         {
             "name": "australiaeast"
+        },
+        {
+            "name": "westus2"
         },
         {
             "name": "westus3"


### PR DESCRIPTION
**Related command**
az functionapp list-flexconsumption-locations

**Description**<!--Mandatory-->
add more flex-consumption locations
![image](https://github.com/kamperiadis/azure-cli/assets/16231002/86b44a48-1307-4fe8-9ffe-53f2f243cccc)


**Testing Guide**
az functionapp list-flexconsumption-locations
![image](https://github.com/kamperiadis/azure-cli/assets/16231002/86b44a48-1307-4fe8-9ffe-53f2f243cccc)
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
